### PR TITLE
Initialized patch system by adding a gitignore change to Flutter.

### DIFF
--- a/patches/.patches
+++ b/patches/.patches
@@ -1,0 +1,1 @@
+added_gclient_files_to_gitignore_to_support_flock_and_other_flutter.patch

--- a/patches/added_gclient_files_to_gitignore_to_support_flock_and_other_flutter.patch
+++ b/patches/added_gclient_files_to_gitignore_to_support_flock_and_other_flutter.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Carroll <matthew-carroll@users.noreply.github.com>
+Date: Sun, 3 Nov 2024 14:49:01 -0800
+Subject: Added gclient files to gitignore to support Flock and other Flutter
+ forks.
+
+
+diff --git a/.gitignore b/.gitignore
+index 3bd906c5e6c83655499850e8a27faefa9430901d..fa41267ba7dd41b4d2931705fe4ecbfc6fe7aafe 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,3 +1,8 @@
++# Injected by Flock to support custom forks
++.gclient
++.gclient_entries
++.gclient_previous_sync_commits
++
+ # Do not remove or rename entries in this file, only add new ones
+ # See https://github.com/flutter/flutter/issues/128635 for more context.
+ 


### PR DESCRIPTION
Initialized patch system by adding a gitignore change to Flutter.

Nest adds a `.glient` file to automatically pull down Flutter (and in the future the engine). But this file is only intended for development. We don't ever want to commit it, or its related files.